### PR TITLE
Added NEWUSERNS support. Now for privilaged unshare containers, a new user namespace is created

### DIFF
--- a/src/unshare.c
+++ b/src/unshare.c
@@ -69,9 +69,9 @@ static pid_t init_unshare_container(struct CONTAINER *container)
 		warning("{yellow}Warning: seems that we could not unshare filesystem information with child process QwQ{clear}\n");
 	}
 	// Add uid and gid map, or it will be nobody(65534) by default.
-	// Copied from `src/rootless.c`
-	uid_t uid = geteuid();
-	gid_t gid = getegid();
+	// Copied from `src/rootless.c`, removed geteuid() & getegid()
+	uid_t uid = 0;
+	gid_t gid = 0;
 	// Set uid map.
 	char uid_map[32] = { "\0" };
 	sprintf(uid_map, "0 %d 1\n", uid);


### PR DESCRIPTION
Added a new user namespace support.
Some software may cause problems to the host when they are not running in a new user namespace.(I guess ;-)
Systemd fails quietly when it's ran in the old user namespace.

After all, It seems harmless to add this support, so why not XD